### PR TITLE
修改了google翻译引擎域名，原translate.google.cn已停止服务

### DIFF
--- a/help.html
+++ b/help.html
@@ -304,7 +304,7 @@ bilibili, https://search.bilibili.com/all?keyword=%s
 爱奇艺, https://so.iqiyi.com/so/q_%s
 
 翻译引擎:
-Google, https://translate.google.cn/?op=translate&text=%s
+Google, https://translate.google.com.hk/?op=translate&text=%s
 Deepl, https://www.deepl.com/translator#any/any/%s
 金山词霸, http://www.iciba.com/word?w=%s
 百度, https://fanyi.baidu.com/#auto/auto/%s

--- a/js/js.js
+++ b/js/js.js
@@ -1121,7 +1121,7 @@ if (in_browser) {
                     ["Yandex", "https://yandex.com/search/?text=%s"],
                 ],
                 翻译引擎: [
-                    ["Google", "https://translate.google.cn/?op=translate&text=%s"],
+                    ["Google", "https://translate.google.com.hk/?op=translate&text=%s"],
                     ["Deepl", "https://www.deepl.com/translator#any/any/%s"],
                     ["金山词霸", "http://www.iciba.com/word?w=%s"],
                     ["百度", "https://fanyi.baidu.com/#auto/auto/%s"],

--- a/main.js
+++ b/main.js
@@ -1784,7 +1784,7 @@ var default_setting = {
         ["Yandex", "https://yandex.com/search/?text=%s"],
     ],
     翻译引擎: [
-        ["Google", "https://translate.google.cn/?op=translate&text=%s"],
+        ["Google", "https://translate.google.com.hk/?op=translate&text=%s"],
         ["Deepl", "https://www.deepl.com/translator#any/any/%s"],
         ["金山词霸", "http://www.iciba.com/word?w=%s"],
         ["百度", "https://fanyi.baidu.com/#auto/auto/%s"],

--- a/setting.html
+++ b/setting.html
@@ -675,7 +675,7 @@
                 <h3>
                     <t>翻译引擎</t>
                 </h3>
-                <textarea id="翻译引擎" placeholder="Google, https://translate.google.cn/?op=translate&text=%s"
+                <textarea id="翻译引擎" placeholder="Google, https://translate.google.com.hk/?op=translate&text=%s"
                     autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
                     title="{换行新建项目，%s代替关键字}"></textarea>
                 <h3>

--- a/src/js/js.ts
+++ b/src/js/js.ts
@@ -1094,7 +1094,7 @@ if (in_browser) {
                     ["Yandex", "https://yandex.com/search/?text=%s"],
                 ],
                 翻译引擎: [
-                    ["Google", "https://translate.google.cn/?op=translate&text=%s"],
+                    ["Google", "https://translate.google.com.hk/?op=translate&text=%s"],
                     ["Deepl", "https://www.deepl.com/translator#any/any/%s"],
                     ["金山词霸", "http://www.iciba.com/word?w=%s"],
                     ["百度", "https://fanyi.baidu.com/#auto/auto/%s"],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/49156890/194490202-3790b792-b64c-4891-8d39-1a881dae3eaa.png)

